### PR TITLE
fix undefined behaviour with bad matches or no match

### DIFF
--- a/offset_finder.py
+++ b/offset_finder.py
@@ -10,6 +10,7 @@ into the SoT ESP Framework
 For community support, please contact me on Discord: DougTheDruid#2784
 """
 import json
+import re
 
 
 ATHENA = "SDK\\Athena_Classes.h"
@@ -37,7 +38,8 @@ def get_offset(file_name, title, memory_object):
             if title == line.replace("\n", ""):
                 past_header = True
             if past_header:
-                if memory_object in line:
+                # this regex looks for a leading space, our property name, and a trailing semicolon
+                if re.search(f"\s{memory_object};", line):
                     offset = line.split("// ")[1].split("(")[0]
                     return int(offset, 0)
 

--- a/offset_finder.py
+++ b/offset_finder.py
@@ -42,6 +42,10 @@ def get_offset(file_name, title, memory_object):
                 if re.search(f"\s{memory_object};", line):
                     offset = line.split("// ")[1].split("(")[0]
                     return int(offset, 0)
+            if past_header and line == '\n': # reached end of property list
+                raise ValueError(f"Unable to find property {memory_object} in {title[3:]}. Check your property name is correct.")
+
+        raise ValueError(f'Unable to find header {title} in {file_name}. Check your header line is correct.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Property names that are unexpectedly substrings of class names, types, or other properties will be incorrectly matched due to this line: https://github.com/DougTheDruid/SoT-Python-Offset-Finder/blob/271572a52f044c204e70914ae57cc443369f82f2/offset_finder.py#L40
For example;
```python
get_offset(ENGINE, "// Class Engine.ChildActorComponent", "ChildActor")
```
gives the following output:
`invalid literal for int() with base 0: 'Class Engine.ChildActorComponent\n'`
Using regex to match more precisely solves this.

Also, if no match is found in the intended class definition, we may end up matching a property in the wrong class, or returning `Null`. It's better to raise exceptions in these cases I believe, to make the user aware.